### PR TITLE
Fix item button size

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,9 +11,9 @@ html
 
 
 
-canvas 
+canvas
 {
-	cursor: none; 
+	cursor: none;
 }
 
 
@@ -84,7 +84,7 @@ canvas
 #btn_item
 {
 	position: absolute;
-	width: 50px;
+	min-width: 50px;
 	height: 50px;
 }
 
@@ -105,4 +105,3 @@ canvas
 
 /* z-index: 30; */
 /* opacity: 0.5; */
-


### PR DESCRIPTION
When name of a button is big enough (like 'ghost detector')
you can't see the hole string but only characters that fit
fixed button width. For example 'ghost detector' looks like
'ghost detecto' missing the 'r' character.

My fix solves the problem by changing 'width' style prop to
'min-width'. So if a button name is not too big you get button
of default size, else if button name is bigger then that the
button just becomes a little wider to fit text inside it.